### PR TITLE
x11: support authenticating other users

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,12 @@
 FROM alpine:3.17
-RUN apk add --no-cache mesa-dri-gallium seatd seatd-launch sway xwayland
+RUN apk add --no-cache mesa-dri-gallium seatd seatd-launch sway xwayland xauth mcookie
 RUN chmod +s /usr/bin/seatd-launch
 COPY config /etc/sway/config
+COPY Xwayland /etc/sway/Xwayland
+RUN chmod +x /etc/sway/Xwayland
+ENV WLR_XWAYLAND=/etc/sway/Xwayland
+COPY .Xauthority /var/lib/sway/.Xauthority
+RUN chmod 777 /var/lib/sway
+ENV XAUTHORITY=/var/lib/sway/.Xauthority
 USER nobody
 ENTRYPOINT ["sway"]

--- a/Xwayland
+++ b/Xwayland
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+exec /usr/bin/Xwayland -auth "$XAUTHORITY" "$@"


### PR DESCRIPTION
This commit adds the xauth and mcookie utilities to the container so
that valid .Xauthority files can be generated, allowing users other than
the Linux user running sway/Xwayland to run applications on X11.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>
